### PR TITLE
Nested solve add check for tolerance of linear iteration step size

### DIFF
--- a/framework/include/utils/NestedSolve.h
+++ b/framework/include/utils/NestedSolve.h
@@ -138,6 +138,7 @@ public:
     CONVERGED_ACCEPTABLE_REL,
     CONVERGED_BOUNDS,
     EXACT_GUESS,
+    CONVERGED_XTOL,
     NOT_CONVERGED
   };
 
@@ -159,6 +160,9 @@ protected:
 
   /// number of nested iterations
   std::size_t _n_iterations;
+
+  // Threshold for minimum step size of linear iterations
+  Real _x_tol;
 
   /// Size a dynamic Jacobian matrix correctly
   void sizeItems(const NestedSolveTempl<is_ad>::DynamicVector & guess,
@@ -424,11 +428,23 @@ NestedSolveTempl<is_ad>::nonlinear(V & guess, T & compute)
 
     // solve and apply next increment
     linear(jacobian, delta, residual);
+
+    //Check if step size is smaller than the floating point tolerance
+    if (delta.cwiseAbs().maxCoeff() <= _x_tol)
+      {
+        _state = State::CONVERGED_XTOL;
+        return;
+      }
+    
     guess -= delta;
     _n_iterations++;
 
     // compute residual and jacobian for the next iteration
-    compute(guess, residual, jacobian);
+    Real _alpha = compute(guess, residual, jacobian);
+
+    // Dampen output if requested
+    guess += (1 - _alpha) * delta;
+    
     r_square = normSquare(residual);
   }
 


### PR DESCRIPTION
Co-authored-by: NAME pierreclement.simon@inl.gov
Co-authored-by: AUTHOR-NAME daniel.schwen@inl.gov
##Reason
Nested Solve does not currently allow the user to set a tolerance for the step size of a linear iteration. This can lead to situations where the exact solution can never be reached because the value falls between two floating point numbers. Additionally, the compute lamda function currently does not allow changing the guess variable value.

##Design
Added two changes:

Add Enum case for when x tolerance was reached (thus solve is converged to the desired numerical precision). The check is performed in the nonlinear method.
Added a return Real value for the 'compute' lamda function. This scales the step size of the linear iteration by the alpha factor. For undamped solves the return value should be 1.
##Impact
This change will prevent solve converge failures when the solution is already accurate to the floating point precision.
It will also allow the nested solve to be used for damped nested solves.